### PR TITLE
Fix hl for YouCompleteMe diagnostic errors

### DIFF
--- a/colors/harlequin.vim
+++ b/colors/harlequin.vim
@@ -325,3 +325,6 @@ call s:Highlight('CtrlPPrtBase',              '', '', 'bold', '')
 "*** taglist.vim ***
 call s:Highlight('TagListTitle',              s:white, '', 'bold', '')
 call s:Highlight('TagListFileName',           s:brick, '', '', '')
+
+"*** YouCompleteMe ***
+call s:Highlight('YcmErrorSection',           s:greys[5], s:mordant, 'bold', '')


### PR DESCRIPTION
Prevents highlighting of YCM compilation diagnostics that
might have had the same background and foreground color
for some syntax class.

However, it replaces the syntax-based coloring by a custom background and foreground
for errors. I personally it better this way.
I don't have any ideas about how to keep the syntactic coloring with guarantees that the highlighted error will always be clearly readable.
